### PR TITLE
Remove second iteration of generator object

### DIFF
--- a/2015/08-31--es6-generators-in-depth/body.markdown
+++ b/2015/08-31--es6-generators-in-depth/body.markdown
@@ -25,7 +25,7 @@ g[Symbol.iterator]() === g
 // the iterator for a generator object is the generator object itself
 console.log(<mark>[...g]</mark>)
 // <- ['f', 'o', 'o']
-console.log(<mark>Array.from(g)</mark>)
+console.log(<mark>Array.from(generator())</mark>)
 // <- ['f', 'o', 'o']
 ```
 


### PR DESCRIPTION
The call to `Array.from(g)` would return `[]`.